### PR TITLE
fix: editor header only show when user is typing

### DIFF
--- a/front-end/src/ui-components/MarkdownEditor.tsx
+++ b/front-end/src/ui-components/MarkdownEditor.tsx
@@ -5,7 +5,7 @@
 import 'react-mde/lib/styles/css/react-mde-all.css';
 
 import styled from '@xstyled/styled-components';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import ReactMde, { Suggestion } from 'react-mde';
 
 import Markdown from './Markdown';
@@ -26,8 +26,9 @@ const StyledTextArea = styled.div`
 				.mde-header-group {
 					margin-left: 0!important;
 					padding: 1rem 0.5rem;
-					background-color: white;
 					width: 100%;
+					display: flex;
+					justify-content: space-between;
 
 					&.hidden {
 						visibility: hidden;
@@ -36,7 +37,9 @@ const StyledTextArea = styled.div`
 
 					.mde-header-item {
 						button {
-							font-size: 1.3rem!important;
+							margin: 0;
+							padding: 0;
+							font-size: 0.85rem!important;
 						}
 					}
 				}
@@ -162,6 +165,28 @@ interface Props {
 
 function MarkdownEditor(props: Props): React.ReactElement {
 
+	const ref = useRef<ReactMde>(null!);
+
+	useEffect(() => {
+		const header = ref.current?.finalRefs?.textarea?.current?.parentNode?.parentNode?.parentNode?.firstChild;
+		(header as any).style.display = 'none';
+		const onFocus = () => {
+			(header as any).style.display = '';
+		};
+		const onBlur = (e: MouseEvent) => {
+			if ((e.currentTarget as any)?.value?.length === 0) {
+				(header as any).style.display = 'none';
+			}
+		};
+		ref.current?.finalRefs?.textarea?.current?.addEventListener('focus', onFocus as any);
+		ref.current?.finalRefs?.textarea?.current?.addEventListener('blur', onBlur as any);
+		return () => {
+			ref.current?.finalRefs?.textarea?.current?.removeEventListener('focus', onFocus as any);
+			// eslint-disable-next-line react-hooks/exhaustive-deps
+			ref.current?.finalRefs?.textarea?.current?.removeEventListener('blur', onBlur as any);
+		};
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ref.current]);
 	const [selectedTab, setSelectedTab] = React.useState<'write' | 'preview'>('write');
 
 	const loadSuggestions = async (text: string) => {
@@ -181,6 +206,7 @@ function MarkdownEditor(props: Props): React.ReactElement {
 	return (
 		<StyledTextArea className='container'>
 			<ReactMde
+				ref={ref}
 				generateMarkdownPreview={markdown => Promise.resolve(<Markdown isPreview={true} md={markdown} />) }
 				minEditorHeight={props.height}
 				minPreviewHeight={props.height}


### PR DESCRIPTION
### Param said show the header when the user is typing.

[text-editor-header.webm](https://user-images.githubusercontent.com/89686019/203307512-3ccfe7cf-1f70-4a7d-8c07-f85ec86129df.webm)
