### PR TITLE
fix footer.tsx for UI of full screen

### DIFF
--- a/front-end/src/components/AppLayout/Footer.tsx
+++ b/front-end/src/components/AppLayout/Footer.tsx
@@ -25,7 +25,7 @@ const Footer = ({ className } : { className?:string }) => {
 
 	return (
 		<footer aria-label="Site Footer" className={`${className} bg-white`}>
-			<div className="mx-auto max-w-screen-xl px-4 pt-12 pb-6 sm:px-6 lg:px-8">
+			<div className="mx-auto max-w-screen-xl px-4 pt-12 pb-6 sm:px-6 lg:pr-8 lg:pl-24">
 				<div className="flex flex-col md:flex-row">
 					{/* Logo and Network Link */}
 					<div>


### PR DESCRIPTION
About section in footer of Polkassembly is overlapping with the side navbar (bottom left) in large screen, corrected the styling.

Before->
<img width="960" alt="before" src="https://user-images.githubusercontent.com/110756551/232187359-fdc23860-4160-4f5b-9c80-e691ea5ff783.png">

After->
<img width="960" alt="after" src="https://user-images.githubusercontent.com/110756551/232187365-740a54b9-764f-47b8-9288-61a53a9c44aa.png">

